### PR TITLE
make deleteInstance delete all instance data

### DIFF
--- a/options/options.js
+++ b/options/options.js
@@ -310,6 +310,7 @@ const deleteInstance = (evt) => {
     let id = evt.target.id.split("#")[1];
     // displayMessage("Forgetting about " + id + "...");
     delete context.knownInstances[id];
+    delete context.instanceOptions[id];
     document.getElementById("knownInstancesList").removeChild(evt.target.parentNode.parentNode); // remove the label element
     document.getElementById("knownInstancesList").removeChild(document.getElementById(id)); // remove the input element
     saveOptions(evt);


### PR DESCRIPTION
Exports showed that `deleteInstance` was deleting instances from the `knownInstances` list but not the `instanceOptions` list. Looks like a simple fix.